### PR TITLE
Shows a case where output is not in subfolder

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -13,10 +13,10 @@ process gender_qc {
   publishDir "results/"
   container 'quay.io/lifebitai/ubuntu'
   output:
-  path "${params.outdir}/results/out.txt"
+  path "${params.outdir}/childpath/out.txt"
   script:
   """
-  mkdir -p ${params.outdir}/results
-  echo 'randomtext' > ${params.outdir}/results/out.txt
+  mkdir -p ${params.outdir}/childpath
+  echo 'randomtext' > ${params.outdir}/childpath/out.txt
   """
 }


### PR DESCRIPTION
Just so that there is no chance results in publishDir and output subpath overlap.